### PR TITLE
Fix bug for Other wattbox types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,6 @@ class SnapAVWattboxInstance extends InstanceBase {
 	async configUpdated(config) {
 		this.config = config;
 
-		this.config.protocol = 'http';
-
 		let model = this.MODELS.find((model) => model.id === this.config.model);
 
 		if (model) {


### PR DESCRIPTION
Given that config.js has a default for protocol, forcibly setting in init.js is not required. It also prevents use of Telnet when selecting Other for wattbox systems.